### PR TITLE
Add files via upload

### DIFF
--- a/book_manager.sql
+++ b/book_manager.sql
@@ -1,64 +1,183 @@
---创建图书管理数据库
-CREATE DATABASE 'book_manager'
+-- phpMyAdmin SQL Dump
+-- version 4.7.4
+-- https://www.phpmyadmin.net/
+--
+-- Host: 127.0.0.1
+-- Generation Time: 2018-05-31 10:58:57
+-- 服务器版本： 10.1.28-MariaDB
+-- PHP Version: 7.1.11
 
---管理员账号数据表
-CREATE TABLE 'admin' (
-  'admin_id' int(10) NOT NULL PRIMARY KEY,
-  'admin_name' varchar(15) NOT NULL,
-  'password' varchar(15) NOT NULL
-)
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+SET AUTOCOMMIT = 0;
+START TRANSACTION;
+SET time_zone = "+00:00";
 
---读者账号数据表
-CREATE TABLE 'reader' (
-  'user_id' int(10) NOT NULL PRIMARY KEY,
-  'user_name' varchar(15) NOT NULL,
-  'password' varchar(15) NOT NULL,
-  'register_day' date NOT NULL,                                      /*注册日期*/
-  'user_state' TINTINT(1) DEFAULT '1' NOT NULL                       /*是否被禁用(默认为可用)*/
-)
 
---图书信息数据表
-CREATE TABLE 'book_info'(
-  'book_id' int(10) NOT NULL AUTO_INCREMENT PRIMARY KEY,
-  'name' varchar(50) NOT NULL,
-  'author' varchar(30) NOT NULL,
-  'ISBN' varchar(20) NOT NULL,
-  'press' varchar(50) NOT NULL,                                      /*出版社*/
-  'number' int(10) NOT NULL,                                         /*通过数量判断是否可借*/
-  'introduction' text
-)
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
 
---借还书申请数据表
-CREATE TABLE 'apply'( 
-  'id' int(10) NOT NULL AUTO_INCREMENT PRIMARY KEY,                 /*操作流水号*/
-  'user_id' int(10) NOT NULL,
-  'book_name' varchar(50) NOT NULL,
-  'author' varchar(30) NOT NULL,
-  'ISBN' varchar(20) NOT NULL,
-  'apply_number' int(10) NOT NULL,                                   /*借阅(或归还)本数*/
-  'apply_time' date NOT NULL,
-  'approval_state' TINTINT(1) DEFAULT '0' NOT NULL,                  /*审批状态(默认为待审批)*/
-  'approval_result' TINTINT(1) DEFAULT '0' NOT NULL                  /*审批结果(默认为未通过)*/
-)
+--
+-- Database: `book_manager`
+--
 
---丢毁反馈数据表
-CREATE TABLE 'lost_feedback'(
-  'id' int(10) NOT NULL AUTO_INCREMENT PRIMARY KEY, 
-  'user_id' int(10) NOT NULL,
-  'book_name' varchar(50) NOT NULL,
-  'author' varchar(30) NOT NULL,
-  'ISBN' varchar(20) NOT NULL,
-  'lost_number' int(10) NOT NULL,                                   /*丢损本数*/
-  'feedback_time' date NOT NULL,                                    /*反馈时间*/
-  'reason'text                                                      /*丢损原因说明*/
-)
+-- --------------------------------------------------------
 
---借还书记录数据表
-CREATE TABLE 'record'(
-  'id' int(10) NOT NULL AUTO_INCREMENT PRIMARY KEY,                  /*操作流水号*/
-  'book_name' varchar(50) NOT NULL,
-  'author' varchar(30) NOT NULL,
-  'ISBN' varchar(20) NOT NULL,
-  'borrow_time' date NOT NULL,
-  'remand_time' date NOT NULL
-)
+--
+-- 表的结构 `admin`
+--
+
+CREATE TABLE `admin` (
+  `admin_id` int(10) NOT NULL,
+  `admin_name` varchar(15) NOT NULL,
+  `password` varchar(15) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+
+--
+-- 表的结构 `admin_record`
+--
+
+CREATE TABLE `admin_record` (
+  `id` int(10) NOT NULL,
+  `ISBN` int(20) NOT NULL,
+  `book_name` varchar(50) NOT NULL,
+  `author` varchar(20) NOT NULL,
+  `user_id` int(10) NOT NULL,
+  `user_name` varchar(15) NOT NULL,
+  `apply_type` tinyint(1) NOT NULL,
+  `operation` int(1) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+
+--
+-- 表的结构 `apply`
+--
+
+CREATE TABLE `apply` (
+  `id` int(10) NOT NULL,
+  `user_id` int(10) NOT NULL,
+  `apply_type` tinyint(1) NOT NULL,
+  `book_id` int(10) NOT NULL,
+  `ISBN` varchar(20) NOT NULL,
+  `approval_state` int(1) NOT NULL DEFAULT '1',
+  `apply_time` int(11) NOT NULL,
+  `reason` text
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+
+--
+-- 表的结构 `book_info`
+--
+
+CREATE TABLE `book_info` (
+  `book_id` int(10) NOT NULL,
+  `name` varchar(50) NOT NULL,
+  `author` varchar(30) NOT NULL,
+  `ISBN` varchar(20) NOT NULL,
+  `press` varchar(50) NOT NULL,
+  `introduction` text NOT NULL,
+  `state` tinyint(1) NOT NULL DEFAULT '1'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+
+--
+-- 表的结构 `reader`
+--
+
+CREATE TABLE `reader` (
+  `user_id` int(10) NOT NULL,
+  `user_name` varchar(15) NOT NULL,
+  `password` varchar(15) NOT NULL,
+  `register_day` date NOT NULL,
+  `user_state` tinyint(1) NOT NULL DEFAULT '1'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+
+--
+-- 表的结构 `user_record`
+--
+
+CREATE TABLE `user_record` (
+  `id` int(10) NOT NULL,
+  `user_id` int(10) NOT NULL,
+  `ISBN` varchar(20) NOT NULL,
+  `book_name` varchar(50) NOT NULL,
+  `author` varchar(30) NOT NULL,
+  `borrow_time` int(11) NOT NULL,
+  `return_time` int(11) NOT NULL DEFAULT '0'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Indexes for dumped tables
+--
+
+--
+-- Indexes for table `admin`
+--
+ALTER TABLE `admin`
+  ADD PRIMARY KEY (`admin_id`);
+
+--
+-- Indexes for table `admin_record`
+--
+ALTER TABLE `admin_record`
+  ADD PRIMARY KEY (`id`);
+
+--
+-- Indexes for table `apply`
+--
+ALTER TABLE `apply`
+  ADD PRIMARY KEY (`id`);
+
+--
+-- Indexes for table `book_info`
+--
+ALTER TABLE `book_info`
+  ADD PRIMARY KEY (`book_id`);
+
+--
+-- Indexes for table `reader`
+--
+ALTER TABLE `reader`
+  ADD PRIMARY KEY (`user_id`);
+
+--
+-- Indexes for table `user_record`
+--
+ALTER TABLE `user_record`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `user_id` (`user_id`);
+
+--
+-- 在导出的表使用AUTO_INCREMENT
+--
+
+--
+-- 使用表AUTO_INCREMENT `admin_record`
+--
+ALTER TABLE `admin_record`
+  MODIFY `id` int(10) NOT NULL AUTO_INCREMENT;
+
+--
+-- 使用表AUTO_INCREMENT `apply`
+--
+ALTER TABLE `apply`
+  MODIFY `id` int(10) NOT NULL AUTO_INCREMENT;
+
+--
+-- 使用表AUTO_INCREMENT `book_info`
+--
+ALTER TABLE `book_info`
+  MODIFY `book_id` int(10) NOT NULL AUTO_INCREMENT;
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;


### PR DESCRIPTION
1.把关于时间的数据类型将date改成了int（11），到时直接储存系统生成的时间戳。
2.根据云课堂的甲方要求把book_info的number删除了，加上了state，储存其图书状态信息。
3.表名record改成user_record，加了user_id并加上了REFERENCES，以便不同的user显示属于自己的user_record。
4.创建了表admin_record，考虑到操作历史只需要展示管理员对哪本书进行了什么操作即可，所以关于图书信息只有book_id、ISBN，没加上author、book_name。
5.将申请操作（借书、还书或丢失）合成一张表，增加apply_type，reason可为空，仅供选择丢失损毁的用户填写。
6.考虑到减少用户界面信息冗杂，对于申请通过的书籍直接进入用户的借阅历史，因此return_time默认为0（借阅通过的情况即为0），还书通过则对return_time进行修改。